### PR TITLE
Support postcss 8

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -1,27 +1,25 @@
 module.exports = {
-	'postcss-input-range': {
-		'basic': {
-			message: 'supports basic usage'
-		},
-		'basic:clone': {
-			message: 'supports "clone" method',
-			options: { method: 'clone' }
-		},
-		'basic:replace': {
-			message: 'supports "replace" method',
-			options: { method: 'replace' }
-		},
-		'basic:warn': {
-			message: 'supports "warn" method',
-			options: { method: 'warn' },
-			warning: 3
-		},
-		'vendor': {
-			message: 'ignores vendor prefixes if strict'
-		},
-		'vendor:loose': {
-			message: 'supports vendor prefixes if not strict',
-			options: { strict: false }
-		}
+	'basic': {
+		message: 'supports basic usage'
+	},
+	'basic:clone': {
+		message: 'supports "clone" method',
+		options: { method: 'clone' }
+	},
+	'basic:replace': {
+		message: 'supports "replace" method',
+		options: { method: 'replace' }
+	},
+	'basic:warn': {
+		message: 'supports "warn" method',
+		options: { method: 'warn' },
+		warnings: 3
+	},
+	'vendor': {
+		message: 'ignores vendor prefixes if strict'
+	},
+	'vendor:loose': {
+		message: 'supports vendor prefixes if not strict',
+		options: { strict: false }
 	}
 };

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Processes prefixed `::range`-type pseudo-classes.
 Add [Input Range] to your build tool:
 
 ```bash
-npm install postcss-input-range --save-dev
+npm install postcss postcss-input-range --save-dev
 ```
 
 #### Node

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 // tooling
 const parser  = require('postcss-selector-parser');
-const postcss = require('postcss');
 
 // pseudo map
 const prefixi = {
@@ -17,7 +16,7 @@ const matcherStrict = /::(range-track|range-thumb|range-lower|range-upper)/i;
 const matcherLoose  = /::(range-track|range-thumb|range-lower|range-upper|-moz-range-track|-ms-track|-webkit-slider-runnable-track|-moz-range-thumb|-ms-thumb|-webkit-slider-thumb|-moz-range-progress|-ms-fill-lower|-ms-fill-upper)/i;
 
 // plugin
-module.exports = postcss.plugin('postcss-input-range', (opts) => {
+module.exports = (opts = {}) => {
 	// options
 	const method = opts && 'method' in opts ? opts.method : 'replace';
 	const strict = opts && 'strict' in opts ? Boolean(opts.strict) : true;
@@ -28,40 +27,45 @@ module.exports = postcss.plugin('postcss-input-range', (opts) => {
 	// pseudo-class matcher
 	const selectorMatch = strict ? matcherStrict : matcherLoose;
 
-	return (css, result) => {
-		// walk each matching rule
-		css.walkRules(selectorMatch, (rule) => {
-			let cloned;
+	return {
+		postcssPlugin: 'postcss-input-range',
+		Once (css, { result }) {
+			// walk each matching rule
+			css.walkRules(selectorMatch, (rule) => {
+				let cloned;
 
-			parser((selectors) => {
-				selectors.each((selector) => {
-					selector.walkPseudos((pseudo) => {
-						Object.keys(prefixi).forEach((name) => {
-							const prefixes = strict ? [name] : prefixi[name].concat(name);
+				parser((selectors) => {
+					selectors.each((selector) => {
+						selector.walkPseudos((pseudo) => {
+							Object.keys(prefixi).forEach((name) => {
+								const prefixes = strict ? [name] : prefixi[name].concat(name);
 
-							if (prefixes.indexOf(pseudo.value) !== -1) {
-								if (safeMethod === 'warn') {
-									result.warn(`${ pseudo.value } detected`, {
-										node: rule
-									});
-								} else {
-									prefixi[name].forEach((prefix) => {
-										pseudo.value = prefix;
-
-										cloned = rule.cloneBefore({
-											selector: selector.toString()
+								if (prefixes.indexOf(pseudo.value) !== -1) {
+									if (safeMethod === 'warn') {
+										result.warn(`${ pseudo.value } detected`, {
+											node: rule
 										});
-									});
+									} else {
+										prefixi[name].forEach((prefix) => {
+											pseudo.value = prefix;
+
+											cloned = rule.cloneBefore({
+												selector: selector.toString()
+											});
+										});
+									}
 								}
-							}
+							});
 						});
 					});
-				});
-			}).process(rule.selector);
+				}).process(rule.selector);
 
-			if (cloned && safeMethod === 'replace') {
-				rule.remove();
-			}
-		});
+				if (cloned && safeMethod === 'replace') {
+					rule.remove();
+				}
+			});
+		},
 	};
-});
+};
+
+module.exports.postcss = true;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "postcss": "^6.0.3 || ^7.0.0 || ^8.0.0",
     "postcss-selector-parser": "^2.2.3"
   },
   "devDependencies": {
@@ -30,6 +29,9 @@
     "eslint": "^8.0.0",
     "eslint-config-dev": "2.0.0",
     "postcss-tape": "2.0.1"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.0"
   },
   "echint": {
     "extends": "dev"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "index.js"
   ],
   "scripts": {
-    "lint": "echint && eslint index.js && jscs index.js",
+    "lint": "echint && eslint index.js",
     "prepublish": "npm test",
     "tape": "postcss-tape",
     "test": "npm run lint && postcss-tape"
@@ -29,8 +29,6 @@
     "echint-config-dev": "1.0.0",
     "eslint": "^4.1.1",
     "eslint-config-dev": "2.0.0",
-    "jscs": "^3.0.7",
-    "jscs-config-dev": "1.0.1",
     "postcss-tape": "2.0.1"
   },
   "echint": {
@@ -41,9 +39,6 @@
     "parserOptions": {
       "sourceType": "module"
     }
-  },
-  "jscsConfig": {
-    "preset": "dev"
   },
   "keywords": [
     "postcss",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "postcss": "^6.0.3",
+    "postcss": "^6.0.3 || ^7.0.0 || ^8.0.0",
     "postcss-selector-parser": "^2.2.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "echint": "^4.0.1",
     "echint-config-dev": "1.0.0",
-    "eslint": "^4.1.1",
+    "eslint": "^8.0.0",
     "eslint-config-dev": "2.0.0",
     "postcss-tape": "2.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "echint-config-dev": "1.0.0",
     "eslint": "^8.0.0",
     "eslint-config-dev": "2.0.0",
-    "postcss-tape": "2.0.1"
+    "postcss-tape": "^6.0.0"
   },
   "peerDependencies": {
     "postcss": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "postcss-selector-parser": "^2.2.3"
+    "postcss-selector-parser": "^6.0.0"
   },
   "devDependencies": {
     "echint": "^4.0.1",


### PR DESCRIPTION
I’m using this plugin with postcss-8 successfully, so I think just updating the version range should be fine.
While doing that, I also cleaned up the vulnerable depndencies.

- Allow postcss 7 and 8
- Remove vulnerable and unmaintained dependency jcsc
- Update eslint to version 8

What do think about upgrading to the [new plugin api](https://evilmartians.com/chronicles/postcss-8-plugin-migration)?